### PR TITLE
Upgrade from Babel 5 to 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   },
   "main": "dist/src",
   "scripts": {
-    "build:src": "babel ./src/ -d ./dist/src/ --modules umd --source-maps",
-    "build:test": "babel ./test/ -d ./dist/test/ --modules umd --source-maps",
-    "build:testkit": "babel ./test-kit/ -d ./dist/test-kit/ --modules umd --source-maps",
-    "pretest": "npm run build:test && npm run build:testkit",
+    "build:src": "babel ./src/ -d ./dist/src/ --source-maps",
+    "build:test": "babel ./test/ -d ./dist/test/ --source-maps",
+    "build:testkit": "babel ./test-kit/ -d ./dist/test-kit/ --source-maps",
+    "pretest": "npm run build:src && npm run build:test && npm run build:testkit",
     "test": "mocha --reporter mocha-env-reporter ./dist/test",
     "start": "webpack-dev-server --progress --hot --inline --no-colors"
   },
@@ -21,13 +21,15 @@
     "Amir Arad <amira@wix.com> (http://github.com/amir-arad)"
   ],
   "devDependencies": {
-    "babel": "5.8.35",
-    "babel-core": "5.8.35",
-    "babel-loader": "5.4.0",
+    "babel-cli": "6.6.5",
+    "babel-core": "6.7.2",
+    "babel-loader": "6.2.4",
+    "babel-plugin-transform-es2015-modules-umd": "6.6.5",
+    "babel-preset-es2015": "6.6.0",
     "chai": "3.5.0",
     "mocha": "2.4.5",
-    "mocha-loader": "0.7.1",
     "mocha-env-reporter": "1.0.2",
+    "mocha-loader": "0.7.1",
     "sinon": "git://github.com/cjohansen/Sinon.JS.git#b672042043517b9f84e14ed0fb8265126168778a",
     "webpack": "1.12.14",
     "webpack-dev-server": "1.14.1"
@@ -38,5 +40,13 @@
   "dependencies": {
     "lodash": "4.6.1",
     "serialize-javascript": "1.2.0"
+  },
+  "babel": {
+    "presets": [
+      "es2015"
+    ],
+    "plugins": [
+      "transform-es2015-modules-umd"
+    ]
   }
 }


### PR DESCRIPTION
Escalate uses the basic es2015 preset with umd modules plugin.

Also made sure pretest builds src.
Our CI automatically runs build:src before testing, but (IMO) external devs should only need to:
  * clone the repo
  * `npm i`
  * `npm test`